### PR TITLE
Fix broken @ref cross-reference causing docs build failure

### DIFF
--- a/docs/src/theory/hamiltonian.md
+++ b/docs/src/theory/hamiltonian.md
@@ -2,7 +2,7 @@
 CurrentModule=OpenQuantumSystems
 ```
 
-# Hamiltonian and Bath Model
+# Hamiltonian & Bath Model
 
 This page summarises the Hamiltonian structure, the linear harmonic oscillator
 (LHO) bath, correlation functions, and the initial-state preparation used


### PR DESCRIPTION
## Root cause

The Documentation CI job was failing because of a broken cross-reference in `docs/src/index.md`:

```markdown
See the [Hamiltonian & Bath Model](@ref) for the underlying theory
```

Documenter.jl resolves `@ref` links by matching the link text against page headings **exactly**. The heading in `docs/src/theory/hamiltonian.md` read:

```markdown
# Hamiltonian and Bath Model
```

`&` ≠ `and` — Documenter cannot resolve the reference and exits with a broken cross-reference error (`:cross_references` is not in `warnonly`, so it is a hard failure).

## Fix

Changed the heading in `hamiltonian.md` from `# Hamiltonian and Bath Model` to `# Hamiltonian & Bath Model`, making it consistent with:
- the navigation title in `docs/make.jl` (`"Hamiltonian & Bath Model"`)
- the `@ref` link in `index.md` (`[Hamiltonian & Bath Model](@ref)`)

## Verification

All other `@ref` links in the docs were checked and resolve correctly against their target headings.