### PR TITLE
Fix duplicate heading slug causing docs build failure

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -140,7 +140,7 @@ Modules = [OpenQuantumSystems]
 Pages   = ["evolution/correlation.jl"]
 ```
 
-## Corrected Memory Kernel
+## Corrected Memory Kernel Functions
 
 ```@autodocs
 Modules = [OpenQuantumSystems]


### PR DESCRIPTION
## Root cause

After the `@ref` fix in PR #94, the docs build failed again with a different error:

```
Cannot resolve [@ref] for "[Corrected Memory Kernel](@ref)" in docs/src/theory/hamiltonian.md.
Header with slug 'Corrected-Memory-Kernel' is not unique.
```

`## Corrected Memory Kernel` in `docs/src/documentation.md` (API reference section) generates the same URL slug as `# Corrected Memory Kernel` in `docs/src/theory/memory_kernel.md` (theory page heading). Documenter.jl cannot resolve the `[Corrected Memory Kernel](@ref)` cross-reference in `hamiltonian.md` because the slug is ambiguous across the two files.

## Fix

Rename the API reference section in `documentation.md` from:
```markdown
## Corrected Memory Kernel
```
to:
```markdown
## Corrected Memory Kernel Functions
```

This makes the slug unique (`Corrected-Memory-Kernel-Functions` vs `Corrected-Memory-Kernel`) and allows the `@ref` in `hamiltonian.md` to unambiguously resolve to the theory page.